### PR TITLE
ustream-openssl: fix call to BIO_get_data

### DIFF
--- a/ustream-openssl.c
+++ b/ustream-openssl.c
@@ -248,7 +248,7 @@ __hidden void __ustream_ssl_context_free(struct ustream_ssl_ctx *ctx)
 __hidden void __ustream_ssl_session_free(struct ustream_ssl *us)
 {
 	BIO *bio = SSL_get_wbio(us->ssl);
-	struct bio_ctx *ctx;
+	struct bio_ctx *ctx = BIO_get_data(bio);
 
 	SSL_shutdown(us->ssl);
 	SSL_free(us->ssl);
@@ -256,7 +256,6 @@ __hidden void __ustream_ssl_session_free(struct ustream_ssl *us)
 	if (!us->conn)
 		return;
 
-	ctx = BIO_get_data(bio);
 	if (ctx) {
 		BIO_meth_free(ctx->meth);
 		free(ctx);


### PR DESCRIPTION
@nbd168 

As I already mentioned in https://github.com/openwrt/ustream-ssl/commit/524a76e5af78fa577c46e0d24bdedd4254e07cd4#r145942773, calling BIO_get_data() after the SSL_free() leads to an segfault, because the BIO will already be freed in SSL_free().

