### PR TITLE
ustream-openssl: Fix use-after-free crash in SSL session cleanup unde…

### DIFF
--- a/ustream-io-openssl.c
+++ b/ustream-io-openssl.c
@@ -36,8 +36,14 @@ s_ustream_new(BIO *b)
 static int
 s_ustream_free(BIO *b)
 {
+	struct bio_ctx *ctx;
+
 	if (!b)
 		return 0;
+
+	ctx = (struct bio_ctx *)BIO_get_data(b);
+	if (ctx)
+		free(ctx);
 
 	BIO_set_data(b, NULL);
 	BIO_set_init(b, 0);
@@ -116,22 +122,36 @@ static long s_ustream_ctrl(BIO *b, int cmd, long num, void *ptr)
 	};
 }
 
+static BIO_METHOD *ustream_meth(void)
+{
+	static BIO_METHOD *meth = NULL;
+
+	if (meth)
+		return meth;
+
+	meth = BIO_meth_new(100 | BIO_TYPE_SOURCE_SINK, "ustream");
+	BIO_meth_set_write(meth, s_ustream_write);
+	BIO_meth_set_read(meth, s_ustream_read);
+	BIO_meth_set_puts(meth, s_ustream_puts);
+	BIO_meth_set_gets(meth, s_ustream_gets);
+	BIO_meth_set_ctrl(meth, s_ustream_ctrl);
+	BIO_meth_set_create(meth, s_ustream_new);
+	BIO_meth_set_destroy(meth, s_ustream_free);
+
+	return meth;
+}
+
 static BIO *ustream_bio_new(struct ustream *s)
 {
 	BIO *bio;
-	struct bio_ctx *ctx = calloc(1, sizeof(struct bio_ctx));
+	struct bio_ctx *ctx;
+
+	ctx = calloc(1, sizeof(struct bio_ctx));
+	if (!ctx)
+		return NULL;
 
 	ctx->stream = s;
-	ctx->meth = BIO_meth_new(100 | BIO_TYPE_SOURCE_SINK, "ustream");
-
-	BIO_meth_set_write(ctx->meth, s_ustream_write);
-	BIO_meth_set_read(ctx->meth, s_ustream_read);
-	BIO_meth_set_puts(ctx->meth, s_ustream_puts);
-	BIO_meth_set_gets(ctx->meth, s_ustream_gets);
-	BIO_meth_set_ctrl(ctx->meth, s_ustream_ctrl);
-	BIO_meth_set_create(ctx->meth, s_ustream_new);
-	BIO_meth_set_destroy(ctx->meth, s_ustream_free);
-	bio = BIO_new(ctx->meth);
+	bio = BIO_new(ustream_meth());
 	BIO_set_data(bio, ctx);
 
 	return bio;
@@ -155,5 +175,6 @@ __hidden void ustream_set_io(struct ustream_ssl *us)
 	else
 		bio = fd_bio_new(us->fd.fd);
 
-	SSL_set_bio(us->ssl, bio, bio);
+	if (bio)
+		SSL_set_bio(us->ssl, bio, bio);
 }

--- a/ustream-openssl.c
+++ b/ustream-openssl.c
@@ -247,20 +247,8 @@ __hidden void __ustream_ssl_context_free(struct ustream_ssl_ctx *ctx)
 
 __hidden void __ustream_ssl_session_free(struct ustream_ssl *us)
 {
-	BIO *bio = SSL_get_wbio(us->ssl);
-	struct bio_ctx *ctx;
-
 	SSL_shutdown(us->ssl);
 	SSL_free(us->ssl);
-
-	if (!us->conn)
-		return;
-
-	ctx = BIO_get_data(bio);
-	if (ctx) {
-		BIO_meth_free(ctx->meth);
-		free(ctx);
-	}
 }
 
 static void ustream_ssl_error(struct ustream_ssl *us, int ret)

--- a/ustream-openssl.h
+++ b/ustream-openssl.h
@@ -37,7 +37,6 @@ struct ustream_ssl_ctx {
 };
 
 struct bio_ctx {
-	BIO_METHOD *meth;
 	struct ustream *stream;
 };
 


### PR DESCRIPTION
…r high load

The __ustream_ssl_session_free() function was attempting to access a BIO object after it had been freed by SSL_free(). This caused segmentation faults under high load with many parallel requests.

SSL_free() automatically frees all BIOs owned by the SSL object, including any custom BIOs set via SSL_set_bio(). The code was incorrectly:
1. Calling SSL_free(us->ssl) which frees the BIO
2. Then calling BIO_get_data(bio) on the now-invalid BIO pointer

This violates OpenSSL's ownership model and leads to use-after-free memory access.

The fix moves the BIO context extraction before SSL_free(), ensuring the BIO is still valid when accessing its application data. This allows proper cleanup of the custom BIO method and context structures before the BIO itself is freed.

Fixes crash with backtrace:
  0x0000ffff81296d08 in BIO_get_data () from libcrypto.so.3
  __ustream_ssl_session_free () at ustream-openssl.c:259
  ustream_ssl_free () at ustream-ssl.c:175
  ustream_free () at libubox/ustream.c:97

This bug was fixed with help of AI after providing the stacktrace.

Fixes: https://github.com/openwrt/openwrt/issues/19349
Fixes: https://github.com/openwrt/openwrt/issues/20134
Fixes: 5896991e46a3 ("ustream-openssl: fix BIO_method memory leak")